### PR TITLE
Fixed question with duplicate answer

### DIFF
--- a/data/questions.yml
+++ b/data/questions.yml
@@ -294,7 +294,7 @@ questions:
         answers:
             - {value: '__get($variable)', correct: true}
             - {value: '__call($method, $params)', correct: true}
-            - {value: '__get($variable)', correct: false}
+            - {value: '__destruct()', correct: false}
             - {value: '__set($variable, $value)', correct: true}
             - {value: '__call($method)', correct: false}
     -


### PR DESCRIPTION
The Answer `__get($variable)` was there two times, once correct and once not. Changed this to __destruct so it will have 5 choices for 3 correct ones.
