### PR TITLE
Fixed wrong answer on user-defined function argument

### DIFF
--- a/data/questions.yml
+++ b/data/questions.yml
@@ -54,8 +54,8 @@ questions:
     -
         question: What is the best way to ensure that a user-defined function is always passed an object as its single parameter?
         answers:
-            - {value: 'function myfunction(stdClass $a)', correct: true}
-            - {value: 'function myfunction($a = stdClass)', correct: false}
+            - {value: 'function myfunction(stdClass $a)', correct: false}
+            - {value: 'function myfunction(callable $a)', correct: true}
             - {value: 'Use is_object() within the function', correct: false}
             - {value: 'There is no way to ensure the parameter will be an object.', correct: false}
             - {value: 'function myfunction(Object $a)', correct: false}


### PR DESCRIPTION
`callable` type hint has been added in PHP 5.4 to serve this purpose.
`stdClass` is wrong since it would not allow a callable as a string (e.g. `"MyClass::myMethod"`, `"functionName"`) or as an array (e.g. `[$myObject, 'myMethod']`).
