### PR TITLE
invalid answer choices and outdated context

### DIFF
--- a/data/questions.yml
+++ b/data/questions.yml
@@ -1,13 +1,13 @@
 category: PHP5.5
 questions:
     -
-        question: 'Which of the following tags are an acceptable way to begin a PHP Code block?'
+        question: 'Which of the following tags are an acceptable way to begin a PHP 5 Code block?'
         answers:
-            - {value: '<SCRIPT LANGUAGE="php">',         correct: true}
-            - {value: '<!',                                                   correct: true}
-            - {value: '<%',                                                 correct: true}
-            - {value: '<?',                                                  correct: true}
-    -
+            - {value: '<SCRIPT LANGUAGE="php">',                              correct: true}
+            - {value: '<!',                                                   correct: false}
+            - {value: '<%',                                                   correct: true}
+            - {value: '<?',                                                   correct: true}
+     -
         question: 'Which of the following are valid PHP variables?'
         answers:
             - {value: '@$foo',      correct: true}


### PR DESCRIPTION
Added PHP version to question context, as PHP 7 removes support for <%=, <% and <script language="php> and changed <! answer value to false, as it is not a valid way to start php code block.
