### PR TITLE
Fixed a typo

### DIFF
--- a/data/questions.yml
+++ b/data/questions.yml
@@ -649,7 +649,7 @@ questions:
             - {value: 'preg_replace', correct: false}
             - {value: 'preg_strip', correct: false}
     -
-        question: 'Identify the best approach to compare to variables in a binary-safe fashion'
+        question: 'Identify the best approach to compare two variables in a binary-safe fashion'
         answers:
             - {value: 'Both strcmp() and $a === $b', correct: true}
             - {value: '$a == $b', correct: false}


### PR DESCRIPTION
But I think the answer is controversial because strcmp is binary safe to compare strings, but it's not even a valid comparison method to compare generic variables (and in the question says "two variables") as it is noticed in http://php.net/manual/es/function.strcmp.php#108563.
