### PR TITLE
Static methods do have access to the `self` keyword (Fix)

### DIFF
--- a/data/oop.yml
+++ b/data/oop.yml
@@ -54,7 +54,7 @@ questions:
             - {value: 'Static methods can only be called using the :: syntax and never from an instance', correct: false}
             - {value: 'Static methods do not provide a reference to $this', correct: true}
             - {value: 'Static methods cannot be called from within class instances', correct: false}
-            - {value: 'Static methods don''t have access to the self keyword', correct: true}
+            - {value: 'Static methods don''t have access to the self keyword', correct: false}
             - {value: 'There is no functional difference between a static and non-static method', correct: false}
 
     -


### PR DESCRIPTION
This PR fixes an error in the answers to the question `What is the primary difference between a method declared as static and a normal method?` and references the issue #15.